### PR TITLE
Define role with enough permissions to perform meaningful checks of 3rd party accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 # .tfvars files
 *.tfvars
+
+test/environments/*

--- a/csw_role/json/policy.json
+++ b/csw_role/json/policy.json
@@ -63,7 +63,7 @@
             ]
         },
         {
-            "Sid": "VisualEditor4",
+            "Sid": "VisualEditor5",
             "Effect": "Allow",
             "Action": [
                 "ec2:DescribeSecurityGroups"
@@ -71,6 +71,26 @@
             "Resource": [
                 "arn:aws:ec2::${account_id}:security-group/*"
             ]
+        },
+        {
+            "Sid": "VisualEditor6",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeRegions"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor7",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListAllMyBuckets",
+                "s3:GetBucketAcl",
+                "s3:GetBucketLogging",
+                "s3:GetBucketPolicy",
+                "s3:GetEncryptionConfiguration"
+            ],
+            "Resource": "arn:aws:s3:::*"
         }
     ]
 }

--- a/csw_role/json/policy.json
+++ b/csw_role/json/policy.json
@@ -66,22 +66,13 @@
             "Sid": "VisualEditor5",
             "Effect": "Allow",
             "Action": [
-                "ec2:DescribeSecurityGroups"
-            ],
-            "Resource": [
-                "arn:aws:ec2::${account_id}:security-group/*"
-            ]
-        },
-        {
-            "Sid": "VisualEditor6",
-            "Effect": "Allow",
-            "Action": [
+                "ec2:DescribeSecurityGroups",
                 "ec2:DescribeRegions"
             ],
             "Resource": "*"
         },
         {
-            "Sid": "VisualEditor7",
+            "Sid": "VisualEditor6",
             "Effect": "Allow",
             "Action": [
                 "s3:ListAllMyBuckets",

--- a/csw_role/json/trust.json
+++ b/csw_role/json/trust.json
@@ -5,7 +5,9 @@
       "Sid": "Statement0",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:lambda:eu-west-2:103495720024:function:csw-dan_audit_account_metric"
+        "AWS": [
+          "arn:aws:iam::${account_id}:role/${prefix}_CstSecurityAgentRole"
+        ]
       },
       "Action": "sts:AssumeRole"
     }

--- a/csw_role/output.tf
+++ b/csw_role/output.tf
@@ -2,6 +2,10 @@ output "role_id" {
   value = "${aws_iam_role.cst_security_inspector_role.id}"
 }
 
+output "role_arn" {
+  value = "${aws_iam_role.cst_security_inspector_role.arn}"
+}
+
 output "policy_id" {
   value = "${aws_iam_role_policy.cst_security_inspector_role_policy.id}"
 }

--- a/csw_role/policy.tf
+++ b/csw_role/policy.tf
@@ -2,8 +2,9 @@ data "template_file" "policy" {
   template = "${file("${path.module}/json/policy.json")}"
 
   vars {
-    prefix     = "${var.prefix}"
-    account_id = "${var.account_id}"
+    prefix      = "${var.prefix}"
+    region      = "${var.region}"
+    account_id  = "${var.target_account_id}"
   }
 }
 

--- a/csw_role/security_inspector_role.tf
+++ b/csw_role/security_inspector_role.tf
@@ -2,8 +2,9 @@ data "template_file" "trust" {
   template = "${file("${path.module}/json/trust.json")}"
 
   vars {
-    prefix     = "${var.prefix}"
-    account_id = "${var.account_id}"
+    prefix      = "${var.prefix}"
+    region      = "${var.region}"
+    account_id  = "${var.agent_account_id}"
   }
 }
 

--- a/csw_role/variables.tf
+++ b/csw_role/variables.tf
@@ -1,5 +1,6 @@
 variable "prefix" {
   default = "prod"
 }
-
-variable "account_id" {}
+variable "region" {}
+variable "agent_account_id" {}
+variable "target_account_id" {}

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,5 +1,7 @@
 module "csw_role" {
-  source     = "../csw_role"
-  prefix     = "csw-dan"
-  account_id = "779799343306"
+  source            = "../csw_role"
+  prefix            = "${var.prefix}"
+  region            = "${var.region}"
+  agent_account_id  = "103495720024"
+  target_account_id = "779799343306"
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -2,6 +2,6 @@ module "csw_role" {
   source            = "../csw_role"
   prefix            = "${var.prefix}"
   region            = "${var.region}"
-  agent_account_id  = "103495720024"
-  target_account_id = "779799343306"
+  agent_account_id  = "${var.agent_account_id}"
+  target_account_id = "${var.target_account_id}"
 }

--- a/test/output.tf
+++ b/test/output.tf
@@ -1,0 +1,11 @@
+output "role_id" {
+  value = "${module.csw_role.role_id}"
+}
+
+output "role_arn" {
+  value = "${module.csw_role.role_arn}"
+}
+
+output "policy_id" {
+  value = "${module.csw_role.policy_id}"
+}

--- a/test/variables.tf
+++ b/test/variables.tf
@@ -1,3 +1,8 @@
 variable "region" {
-  default = "eu-west-2"
+  default = "eu-west-1"
 }
+
+
+variable "prefix" {}
+variable "agent_account_id" {}
+variable "target_account_id" {}


### PR DESCRIPTION
The distributable is the csw_role module. The test folder shows how to invoke it.  agent_account_id is the AWS account ID of our service. target_account_id is the AWS account ID of the service being interrogated. Prefix allows us to run the tool in non-live environments. 