### PR TITLE
Allow all support operations to enable Trusted Advisor checks

### DIFF
--- a/csw_role/json/policy.json
+++ b/csw_role/json/policy.json
@@ -5,8 +5,7 @@
             "Sid": "VisualEditor0",
             "Effect": "Allow",
             "Action": [
-                "support:DescribeTrustedAdvisorCheckResult",
-                "support:DescribeTrustedAdvisorChecks"
+                "support:*"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
The permissions assigned for trusted advisor were not enough to run trusted advisor checks. I've had to enable support:*. I don't really understand why this is necessary because it gives us permission to raise support cases but I tried with all but those permissions and it still didn't work.