### PR TITLE
Describe permissions fix

### DIFF
--- a/csw_role/json/policy.json
+++ b/csw_role/json/policy.json
@@ -104,12 +104,18 @@
             "Sid": "VisualEditor9",
             "Effect": "Allow",
             "Action": [
-                "kms:ListKeys",
+                "kms:ListKeys"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor9",
+            "Effect": "Allow",
+            "Action": [
                 "kms:GetKeyRotationStatus",
                 "kms:DescribeKey"
             ],
             "Resource": "arn:aws:kms:*:${account_id}:*"
         }
-
     ]
 }

--- a/csw_role/json/policy.json
+++ b/csw_role/json/policy.json
@@ -95,7 +95,14 @@
             "Sid": "VisualEditor8",
             "Effect": "Allow",
             "Action": [
-                "cloudtrail:DescribeTrails",
+                "cloudtrail:DescribeTrails"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor8.1",
+            "Effect": "Allow",
+            "Action": [
                 "cloudtrail:GetTrailStatus"
             ],
             "Resource": "arn:aws:cloudtrail::${account_id}:*"
@@ -109,7 +116,7 @@
             "Resource": "*"
         },
         {
-            "Sid": "VisualEditor9",
+            "Sid": "VisualEditor9.1",
             "Effect": "Allow",
             "Action": [
                 "kms:GetKeyRotationStatus",


### PR DESCRIPTION
Separated the cloudtrail DescribeTrails and kms ListKeys permissions into separate policy statements with a more permissive resource ARN. 