### PR TITLE
get target account id from aws_caller_identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ module "csw_inspector_role" {
   region                = "eu-west-1"
   csw_prefix            = "${var.csw_prefix}"
   csw_agent_account_id  = "${var.csw_agent_account_id}"
-  csw_target_account_id = "${var.csw_target_account_id}"
 }
 ```
 
@@ -65,7 +64,6 @@ module "csw_role" {
   source            = "relative/path/to/csw_role"
   prefix            = "${var.csw_prefix}"
   agent_account_id  = "${var.csw_agent_account_id}"
-  target_account_id = "${var.csw_target_account_id}"
 }
 ```
 
@@ -78,7 +76,6 @@ variable "csw_prefix" {
     default = "csw-prod"
 }
 variable "csw_agent_account_id" {}
-variable "csw_target_account_id" {}
 ```
 
 ### Create a tfvar file 
@@ -96,7 +93,6 @@ environment.
 ```csw-apply.tfvars
 csw_prefix = "[environment]"
 csw_agent_account_id = "[our account id]"
-csw_target_account_id = "[your account id]"
 ```
 
 ## Policy Statements

--- a/csw_role/policy.tf
+++ b/csw_role/policy.tf
@@ -1,9 +1,11 @@
+data "aws_caller_identity" "current" {}
+
 data "template_file" "policy" {
   template = "${file("${path.module}/json/policy.json")}"
 
   vars {
-    prefix      = "${var.prefix}"
-    account_id  = "${var.target_account_id}"
+    prefix     = "${var.prefix}"
+    account_id = "${data.aws_caller_identity.current.account_id}"
   }
 }
 

--- a/csw_role/variables.tf
+++ b/csw_role/variables.tf
@@ -1,3 +1,2 @@
 variable "prefix" {}
 variable "agent_account_id" {}
-variable "target_account_id" {}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 module "csw_role" {
-  source            = "./csw_role"
-  prefix            = "${var.csw_prefix}"
-  agent_account_id  = "${var.csw_agent_account_id}"
-  target_account_id = "${var.csw_target_account_id}"
+  source           = "./csw_role"
+  prefix           = "${var.csw_prefix}"
+  agent_account_id = "${var.csw_agent_account_id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,15 @@
 variable "csw_prefix" {
-    default = "csw-prod"
+  default = "csw-prod"
 }
+
 /*
 Region is only used for the provider.
 If you are implementing our module in your own terraform
 it's not needed.
 */
+
 variable "region" {
-    default = "eu-west-1"
+  default = "eu-west-1"
 }
+
 variable "csw_agent_account_id" {}
-variable "csw_target_account_id" {}


### PR DESCRIPTION
This is a breaking change which removes the `csw_target_account_id`
variable and instead gets the target account id from the
[`aws_caller_identity` data source][1].  The advantage is that it's
less configuration for the user to pass in.

I considered making this a graceful change which simply adds a default
value to the csw_target_account_id so that existing clients continue
to work but I think it's probably easiest to just make the change and
update consumers.  However, if people are depending on `master` then
their terraform builds may suddenly break.

[1]: https://www.terraform.io/docs/providers/aws/d/caller_identity.html