### PR TITLE
[CT-591] Added s3:GetEncryptionConfiguration action

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ so we have customised the rules and therefore need access to the
 raw data.
 
 ### Statement 6 - s3 ListAllBuckets, all configuration Gets
-#### GetBucketAcl, GetBucketLogging, GetBucketPolicy, GetEncryptionConfiguration, GetBucketVersioning
+#### GetBucketAcl, GetBucketLogging, GetBucketPolicy, GetEncryptionConfiguration, GetBucketVersioning, GetEncryptionConfiguration
 
 This statement allows us to get the configuration settings of 
 S3 buckets without granting us any visibility over the bucket 

--- a/csw_role/json/policy.json
+++ b/csw_role/json/policy.json
@@ -80,7 +80,8 @@
                 "s3:GetBucketLogging",
                 "s3:GetBucketPolicy",
                 "s3:GetEncryptionConfiguration",
-                "s3:GetBucketVersioning"
+                "s3:GetBucketVersioning",
+                "s3:GetEncryptionConfiguration"
             ],
             "Resource": "arn:aws:s3:::*"
         },


### PR DESCRIPTION
This is one of the rare cases where the Action string does not match up
with the API call name. Threw me for a loop.

Related `csw-backend` PR: https://github.com/alphagov/csw-backend/pull/79