### PR TITLE
bump to terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 module "csw_role" {
   source           = "./csw_role"
-  prefix           = "${var.csw_prefix}"
-  agent_account_id = "${var.csw_agent_account_id}"
+  prefix           = var.csw_prefix
+  agent_account_id = var.csw_agent_account_id
 }
+

--- a/output.tf
+++ b/output.tf
@@ -1,11 +1,12 @@
 output "csw_role_id" {
-  value = "${module.csw_role.role_id}"
+  value = module.csw_role.role_id
 }
 
 output "csw_role_arn" {
-  value = "${module.csw_role.role_arn}"
+  value = module.csw_role.role_arn
 }
 
 output "csw_policy_id" {
-  value = "${module.csw_role.policy_id}"
+  value = module.csw_role.policy_id
 }
+

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,4 @@
 provider "aws" {
-  region = "${var.region}"
+  region  = var.region
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This upgrades the module to terraform 0.12.

Terraform 0.12 has been out for a while.  Continuing to use tf 0.11
syntax in here causes deprecation warnings in consumers, such as:

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/csw_role/provider.tf line 2, in provider "aws":
   2:   region = "${var.region}"
```

This commit upgrades to tf 0.12, mostly by running the handy
`terraform 0.12upgrade` command.

Consumers should pin to a commit hash so this shouldn't break existing
users.