### PR TITLE
Make it easier to remove this module

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  region  = var.region
-}
-


### PR DESCRIPTION
This repo is (apparently) deprecated.  However removing it from my
codebase doesn't work because I get the error:

```
Error: Provider configuration not present

To work with
module.csw_role.module.csw_role.aws_iam_role_policy.cst_security_inspector_role_policy
its original provider configuration at module.csw_role.provider.aws is
required, but it has been removed. This occurs when a provider configuration
is removed while objects created by that provider still exist in the state.
Re-add the provider configuration to destroy
module.csw_role.module.csw_role.aws_iam_role_policy.cst_security_inspector_role_policy,
after which you can remove the provider configuration again.
```

I think this is because the module has some provider configuration,
and deleting it means it can't work out how to delete the resources.

Note that this module only creates IAM resources which are global and
not regioned.

Note also, I deliberately didn't remove the region variable even
though it isn't used any more.